### PR TITLE
fix: correct frontend tech stack in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,13 +36,10 @@ _Coming soon_
 - Queue system for background jobs
 
 **Frontend:**
-- Vue 2
-- TypeScript
-- Vite
-- Tailwind CSS 4
-- Radix UI components
-- TanStack Query
-- Wouter (routing)
+- Vue 3
+- Vite 5
+- Tailwind CSS 3
+- Vue Router 4
 
 **Browser Extension:**
 - Chrome Extension Manifest V3


### PR DESCRIPTION
The README incorrectly listed React libraries (Radix UI, TanStack Query, Wouter) alongside Vue, which is impossible since they're incompatible.

Corrected:
- Vue 2 → Vue 3
- Removed TypeScript (not used)
- Tailwind CSS 4 → Tailwind CSS 3
- Removed React-only libraries (Radix UI, TanStack Query, Wouter)
- Added Vue Router 4 (actual routing library)

<!-- Link related issues: Closes #123, Fixes #456 -->
